### PR TITLE
Regenerate things in startPairing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "virtual-things-adapter",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Mozilla IoT Virtual Things Adapter",
   "main": "index.js",
   "keywords": [

--- a/virtual-things-adapter.js
+++ b/virtual-things-adapter.js
@@ -283,9 +283,19 @@ class VirtualThingsAdapter extends Adapter {
 
     adapterManager.addAdapter(this);
 
+    this.addAllThings();
+  }
+
+  startPairing() {
+    this.addAllThings();
+  }
+
+  addAllThings() {
     for (let i = 0; i < VIRTUAL_THINGS.length; i++) {
       var id = 'virtual-things-' + i;
-      new VirtualThingsDevice(this, id, VIRTUAL_THINGS[i]);
+      if (!this.devices[id]) {
+        new VirtualThingsDevice(this, id, VIRTUAL_THINGS[i]);
+      }
     }
   }
 }


### PR DESCRIPTION
Solves an issue where removing a Thing would remove it until the Gateway
was restarted.