### PR TITLE
brightness: Align shema to spec

### DIFF
--- a/virtual-things-adapter.js
+++ b/virtual-things-adapter.js
@@ -123,7 +123,7 @@ function colorTemperature() {
 
 function brightness() {
   return {
-    name: 'level',
+    name: 'brightness',
     value: 0,
     metadata: {
       title: 'Brightness',


### PR DESCRIPTION
According to:

https://iot.mozilla.org/wot/#example-2-a-more-complex-thing-description-with-semantic-annotations

For some reason, "brightness" name is preferred over "level" one.

Change-Id: I09b81c0aaa6d5e26b6a6c30f731a5646217e5e67
Relate-to: https://github.com/mozilla-iot/webthing-node/pull/108
Signed-off-by: Philippe Coval <p.coval@samsung.com>