### PR TITLE
Tweak OS and Node versions and rebuild sqlite3 to make adapter work in Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version: [

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 8
+          node-version: 20
       - name: Set release version
         run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
       - name: Package project

--- a/package.sh
+++ b/package.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
-rm -rf node_modules
-
 npm ci --production
+# Rebuild sqlite3 for the version of glibc shipped with this OS
+npm rebuild sqlite3 --build-from-source
 
 # Remove internal package-lock cache which can cause checksum errors at runtime
 rm -f node_modules/.package-lock.json


### PR DESCRIPTION
The pre-built binaries that come with sqlite3 require glibc 2.38 which is not available inside the Debian Bookworm based Docker images.

This PR reduces the GitHub Actions runner to Ubuntu 22.04 and re-builds the sqlite3 package on that OS against an older glibc which should be compatible with the ones that ship with Debian Bookworm.